### PR TITLE
修改: tendermint依赖版本修改

### DIFF
--- a/account/account.go
+++ b/account/account.go
@@ -10,14 +10,14 @@ type Account interface {
 	SetAddress(addr types.Address) error
 	GetPubicKey() crypto.PubKey
 	SetPublicKey(pubKey crypto.PubKey) error
-	GetNonce() int64
-	SetNonce(nonce int64) error
+	GetNonce() uint64
+	SetNonce(nonce uint64) error
 }
 
 type BaseAccount struct {
 	AccountAddress types.Address `json:"account_address"` // account address
 	Publickey      crypto.PubKey `json:"public_key"`      // public key
-	Nonce          int64         `json:"nonce"`           // identifies tx_status of an account
+	Nonce          uint64        `json:"nonce"`           // identifies tx_status of an account
 }
 
 func ProtoBaseAccount() Account {
@@ -50,12 +50,12 @@ func (accnt *BaseAccount) SetPublicKey(pubKey crypto.PubKey) error {
 }
 
 // getter for nonce
-func (accnt *BaseAccount) GetNonce() int64 {
+func (accnt *BaseAccount) GetNonce() uint64 {
 	return accnt.Nonce
 }
 
 // setter for nonce
-func (accnt *BaseAccount) SetNonce(nonce int64) error {
+func (accnt *BaseAccount) SetNonce(nonce uint64) error {
 	accnt.Nonce = nonce
 	return nil
 }

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -36,22 +36,22 @@ func TestAccountMarshal(t *testing.T) {
 
 	err := baseAccount.SetPublicKey(pub)
 	require.Nil(t, err)
-	err = baseAccount.SetNonce(int64(7))
+	err = baseAccount.SetNonce(7)
 	require.Nil(t, err)
 
-	add_binary, err := cdc.MarshalBinary(baseAccount)
+	add_binary, err := cdc.MarshalBinaryLengthPrefixed(baseAccount)
 	require.Nil(t, err)
 
 	another_add := BaseAccount{}
 	another_json := []byte{}
-	err = cdc.UnmarshalBinary(add_binary, &another_add)
+	err = cdc.UnmarshalBinaryLengthPrefixed(add_binary, &another_add)
 	require.Nil(t, err)
 	require.Equal(t, baseAccount, another_add)
 
 	// error on bad bytes
 	another_add = BaseAccount{}
 	another_json = []byte{}
-	err = cdc.UnmarshalBinary(add_binary[:len(add_binary)/2], &another_json)
+	err = cdc.UnmarshalBinaryLengthPrefixed(add_binary[:len(add_binary)/2], &another_json)
 	require.NotNil(t, err)
 
 }

--- a/account/accountmapper.go
+++ b/account/accountmapper.go
@@ -95,7 +95,7 @@ func (mapper *AccountMapper) GetPubKey(addr types.Address) (crypto.PubKey, types
 }
 
 // 获取地址代表账户的nonce
-func (mapper *AccountMapper) GetNonce(addr types.Address) (int64, types.Error) {
+func (mapper *AccountMapper) GetNonce(addr types.Address) (uint64, types.Error) {
 	acc := mapper.GetAccount(addr)
 	if acc == nil {
 		return 0, types.ErrUnknownAddress(addr.String())
@@ -104,7 +104,7 @@ func (mapper *AccountMapper) GetNonce(addr types.Address) (int64, types.Error) {
 }
 
 // 为特定账户设置新的nonce值
-func (mapper *AccountMapper) SetNonce(addr types.Address, nonce int64) types.Error {
+func (mapper *AccountMapper) SetNonce(addr types.Address, nonce uint64) types.Error {
 	acc := mapper.GetAccount(addr)
 	if acc == nil {
 		return types.ErrUnknownAddress(addr.String())

--- a/account/accountmapper_test.go
+++ b/account/accountmapper_test.go
@@ -60,7 +60,7 @@ func TestAccountMapperGetSet(t *testing.T) {
 		// 新的account尚未存储，依然取出nil
 		require.Nil(t, mapper.GetAccount(addr))
 
-		nonce := int64(20)
+		nonce := uint64(20)
 		acc.SetNonce(nonce)
 		acc.SetPublicKey(pubkey)
 		// 存储account

--- a/client/account/account.go
+++ b/client/account/account.go
@@ -52,7 +52,7 @@ func GetAccountFromBech32Addr(ctx context.CLIContext, bech32Addr string) (accoun
 	return queryAccount(ctx, addrBytes)
 }
 
-func GetAccountNonce(ctx context.CLIContext, address []byte) (int64, error) {
+func GetAccountNonce(ctx context.CLIContext, address []byte) (uint64, error) {
 	account, err := queryAccount(ctx, address)
 
 	if err == ErrAccountNotExsits {

--- a/client/block/store.go
+++ b/client/block/store.go
@@ -97,7 +97,7 @@ func tryDecodeValue(cdc *go_amino.Codec, bz []byte, useKVPairFlag bool) (interfa
 
 	if useKVPairFlag {
 		var vKVPair []store.KVPair
-		err = cdc.UnmarshalBinary(bz, &vKVPair)
+		err = cdc.UnmarshalBinaryLengthPrefixed(bz, &vKVPair)
 		if err == nil {
 			var pairResults []kvPairResult
 			for _, pair := range vKVPair {

--- a/client/context/context.go
+++ b/client/context/context.go
@@ -104,8 +104,8 @@ func (ctx CLIContext) query(path string, key cmn.HexBytes) (res []byte, err erro
 	}
 
 	opts := rpcclient.ABCIQueryOptions{
-		Height:  ctx.Height,
-		Trusted: ctx.TrustNode,
+		Height: ctx.Height,
+		Prove:  ctx.TrustNode,
 	}
 
 	result, err := node.ABCIQueryWithOptions(path, key, opts)

--- a/client/keys/add.go
+++ b/client/keys/add.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	go_amino "github.com/tendermint/go-amino"
-	"github.com/tendermint/tmlibs/cli"
+	"github.com/tendermint/tendermint/libs/cli"
 )
 
 const (

--- a/client/keys/util.go
+++ b/client/keys/util.go
@@ -11,7 +11,7 @@ import (
 	btypes "github.com/QOSGroup/qbase/types"
 	"github.com/spf13/viper"
 
-	"github.com/tendermint/tmlibs/cli"
+	"github.com/tendermint/tendermint/libs/cli"
 
 	dbm "github.com/tendermint/tendermint/libs/db"
 )

--- a/client/qcp/cmd.go
+++ b/client/qcp/cmd.go
@@ -102,7 +102,7 @@ $ basecli qcp tx [chainID] --seq [Seq]
 			seq := viper.GetInt64(flagOutSeq)
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
-			result, err := GetGetOutChainTx(cliCtx, outChainID, seq)
+			result, err := GetGetOutChainTx(cliCtx, outChainID, uint64(seq))
 
 			if err != nil {
 				return err

--- a/client/qcp/qcp.go
+++ b/client/qcp/qcp.go
@@ -16,7 +16,7 @@ func query(ctx context.CLIContext, key []byte) ([]byte, error) {
 	return ctx.Query(string(path), key)
 }
 
-func GetOutChainSequence(ctx context.CLIContext, outChainID string) (int64, error) {
+func GetOutChainSequence(ctx context.CLIContext, outChainID string) (uint64, error) {
 	key := qcp.BuildOutSequenceKey(outChainID)
 	bz, err := query(ctx, key)
 
@@ -28,7 +28,7 @@ func GetOutChainSequence(ctx context.CLIContext, outChainID string) (int64, erro
 		return 0, fmt.Errorf("GetOutChainSequence return empty. there is not exists %s out sequence", outChainID)
 	}
 
-	var seq int64
+	var seq uint64
 	err = ctx.Codec.UnmarshalBinaryBare(bz, &seq)
 	if err != nil {
 		return 0, err
@@ -37,7 +37,7 @@ func GetOutChainSequence(ctx context.CLIContext, outChainID string) (int64, erro
 	return seq, nil
 }
 
-func GetGetOutChainTx(ctx context.CLIContext, outChainID string, seq int64) (*txs.TxQcp, error) {
+func GetGetOutChainTx(ctx context.CLIContext, outChainID string, seq uint64) (*txs.TxQcp, error) {
 	key := qcp.BuildOutSequenceTxKey(outChainID, seq)
 	bz, err := query(ctx, key)
 
@@ -58,7 +58,7 @@ func GetGetOutChainTx(ctx context.CLIContext, outChainID string, seq int64) (*tx
 	return &tx, nil
 }
 
-func GetInChainSequence(ctx context.CLIContext, inChainID string) (int64, error) {
+func GetInChainSequence(ctx context.CLIContext, inChainID string) (uint64, error) {
 	key := qcp.BuildInSequenceKey(inChainID)
 	bz, err := query(ctx, key)
 
@@ -70,7 +70,7 @@ func GetInChainSequence(ctx context.CLIContext, inChainID string) (int64, error)
 		return 0, fmt.Errorf("GetInChainSequence return empty. there is not exists %s in sequence", key)
 	}
 
-	var seq int64
+	var seq uint64
 	err = ctx.Codec.UnmarshalBinaryBare(bz, &seq)
 	if err != nil {
 		return 0, err
@@ -99,7 +99,7 @@ func QueryQcpChainsInfo(ctx context.CLIContext) ([]qcpChainsResult, error) {
 	}
 
 	var kvPair []store.KVPair
-	err = ctx.Codec.UnmarshalBinary(res, &kvPair)
+	err = ctx.Codec.UnmarshalBinaryLengthPrefixed(res, &kvPair)
 	if err != nil {
 		return nil, err
 	}

--- a/client/tx/utils.go
+++ b/client/tx/utils.go
@@ -92,8 +92,8 @@ func BuildAndSignQcpTx(ctx context.CLIContext, tx txs.ITx) (*txs.TxQcp, error) {
 	txQcp := txs.NewTxQCP(txStd, qcpFrom,
 		toChainID,
 		qcpSeq+1,
-		viper.GetInt64(cflags.FlagQcpBlockHeight),
-		viper.GetInt64(cflags.FlagQcpTxIndex),
+		uint64(viper.GetInt64(cflags.FlagQcpBlockHeight)),
+		uint64(viper.GetInt64(cflags.FlagQcpTxIndex)),
 		ok,
 		viper.GetString(cflags.FlagQcpExtends),
 	)
@@ -109,15 +109,15 @@ func BuildAndSignQcpTx(ctx context.CLIContext, tx txs.ITx) (*txs.TxQcp, error) {
 
 func BuildAndSignStdTx(ctx context.CLIContext, tx txs.ITx, txStdFromChainID string) (*txs.TxStd, error) {
 
-	accountNonce := viper.GetInt64(cflags.FlagNonce)
-	maxGas := viper.GetInt64(cflags.FlagMaxGas)
+	accountNonce := uint64(viper.GetInt64(cflags.FlagNonce))
+	maxGas := uint64(viper.GetInt64(cflags.FlagMaxGas))
 	if maxGas < 0 {
 		return nil, errors.New("max-gas flag not correct")
 	}
 
 	chainID := getChainID(ctx)
 	signers := getSigners(ctx, tx.GetSigner())
-	txStd := txs.NewTxStd(tx, chainID, types.NewInt(maxGas))
+	txStd := txs.NewTxStd(tx, chainID, types.NewUint(maxGas))
 
 	isUseFlagAccountNonce := accountNonce > 0
 	for _, signerName := range signers {
@@ -126,7 +126,7 @@ func BuildAndSignStdTx(ctx context.CLIContext, tx txs.ITx, txStdFromChainID stri
 			return nil, err
 		}
 
-		var actualNonce int64
+		var actualNonce uint64
 		if isUseFlagAccountNonce {
 			actualNonce = accountNonce + 1
 		} else {
@@ -146,7 +146,7 @@ func BuildAndSignStdTx(ctx context.CLIContext, tx txs.ITx, txStdFromChainID stri
 	return txStd, nil
 }
 
-func signStdTx(ctx context.CLIContext, signerKeyName string, nonce int64, txStd *txs.TxStd, txStdFromChainID string) (*txs.TxStd, error) {
+func signStdTx(ctx context.CLIContext, signerKeyName string, nonce uint64, txStd *txs.TxStd, txStdFromChainID string) (*txs.TxStd, error) {
 
 	info, err := keys.GetKeyInfo(ctx, signerKeyName)
 	if err != nil {
@@ -220,8 +220,8 @@ func getSigners(ctx context.CLIContext, txSignerAddrs []types.Address) []string 
 	return sortNames
 }
 
-func getQcpInSequence(ctx context.CLIContext, inChainID string) int64 {
-	seq := viper.GetInt64(cflags.FlagQcpSequence)
+func getQcpInSequence(ctx context.CLIContext, inChainID string) uint64 {
+	seq := uint64(viper.GetInt64(cflags.FlagQcpSequence))
 	if seq > 0 {
 		return seq
 	}
@@ -254,7 +254,7 @@ func getDefaultChainID(ctx context.CLIContext) (string, error) {
 	return genesis.Genesis.ChainID, nil
 }
 
-func getDefaultAccountNonce(ctx context.CLIContext, address []byte) (int64, error) {
+func getDefaultAccountNonce(ctx context.CLIContext, address []byte) (uint64, error) {
 
 	if ctx.NonceNodeURI == "" {
 		return account.GetAccountNonce(ctx, address)

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -156,7 +156,7 @@ func TestContextWithCustom(t *testing.T) {
 	require.Panics(t, func() { ctx.ChainID() })
 	require.Panics(t, func() { ctx.TxBytes() })
 	require.Panics(t, func() { ctx.Logger() })
-	require.Panics(t, func() { ctx.SigningValidators() })
+	require.Panics(t, func() { ctx.VoteInfos() })
 	require.Panics(t, func() { ctx.GasMeter() })
 
 	header := abci.Header{}
@@ -165,7 +165,7 @@ func TestContextWithCustom(t *testing.T) {
 	ischeck := true
 	txbytes := []byte("txbytes")
 	logger := NewMockLogger()
-	signvals := []abci.SigningValidator{{}}
+	signvals := []abci.VoteInfo{{}}
 	meter := types.NewGasMeter(10000)
 	minFees := make([]types.Coin, 1)
 	blockTxIndex := int64(100)
@@ -178,19 +178,18 @@ func TestContextWithCustom(t *testing.T) {
 		WithBlockHeight(height).
 		WithChainID(chainid).
 		WithTxBytes(txbytes).
-		WithSigningValidators(signvals).
+		WithVoteInfos(signvals).
 		WithGasMeter(meter).
 		WithMinimumFees(minFees).
 		WithBlockTxIndex(blockTxIndex).
 		WithTxQcpResultHandler(handerler)
 
-	require.Equal(t, header, ctx.BlockHeader())
 	require.Equal(t, height, ctx.BlockHeight())
 	require.Equal(t, chainid, ctx.ChainID())
 	require.Equal(t, ischeck, ctx.IsCheckTx())
 	require.Equal(t, txbytes, ctx.TxBytes())
 	require.Equal(t, logger, ctx.Logger())
-	require.Equal(t, signvals, ctx.SigningValidators())
+	require.Equal(t, signvals, ctx.VoteInfos())
 	require.Equal(t, meter, ctx.GasMeter())
 	require.Equal(t, blockTxIndex, ctx.BlockTxIndex())
 

--- a/example/basecoin/README.md
+++ b/example/basecoin/README.md
@@ -14,7 +14,7 @@ $ go install
 ```
 2. 初始化
 ```
-$ basecoind init
+$ basecoind init --chain-id basecoin --name node
 ```
 
 ```
@@ -47,7 +47,7 @@ book distance cart design another view olympic orbit leopard indoor tumble dutch
 ```
 4. 启动basecoin app
 ```
-$ basecoind start --with-tendermint=true
+$ basecoind start
 ```
 5. 账户查询状态
 ```

--- a/example/basecoin/cmd/basecoind/main.go
+++ b/example/basecoin/cmd/basecoind/main.go
@@ -26,8 +26,7 @@ func main() {
 	// version cmd
 	rootCmd.AddCommand(version.VersionCmd)
 
-	server.AddCommands(ctx, cdc, rootCmd, types.BaseCoinInit(),
-		server.ConstructAppCreator(newApp, "basecoin"))
+	server.AddCommands(ctx, cdc, rootCmd, types.BaseCoinInit(), newApp)
 
 	executor := cli.PrepareBaseCmd(rootCmd, "basecoin", types.DefaultNodeHome)
 

--- a/example/basecoin/tx/SendTx.go
+++ b/example/basecoin/tx/SendTx.go
@@ -33,13 +33,13 @@ func (tx *SendTx) ValidateData(ctx context.Context) error {
 
 func (tx *SendTx) Exec(ctx context.Context) (result btypes.Result, crossTxQcps *txs.TxQcp) {
 	result = btypes.Result{
-		Code: btypes.ABCICodeOK,
+		Code: btypes.CodeOK,
 	}
 	// 查询发送方账户信息
 	mapper := baseabci.GetAccountMapper(ctx)
 	fromAcc := mapper.GetAccount(tx.From).(*types.AppAccount)
 	if fromAcc.AccountAddress == nil {
-		result.Code = btypes.ABCICodeType(btypes.CodeInternal)
+		result.Code = btypes.CodeInternal
 		return
 	}
 	// 校验发送金额
@@ -48,14 +48,14 @@ func (tx *SendTx) Exec(ctx context.Context) (result btypes.Result, crossTxQcps *
 		if c.Name == tx.Coin.Name {
 			exists = true
 			if c.Amount.LT(tx.Coin.Amount) {
-				result.Code = btypes.ABCICodeType(btypes.CodeInternal)
+				result.Code = btypes.CodeInternal
 				result.Log = fmt.Sprintf("coin %s has not much amount %d", c.Name, c.Amount.Int64())
 				return
 			}
 		}
 	}
 	if !exists {
-		result.Code = btypes.ABCICodeType(btypes.CodeInternal)
+		result.Code = btypes.CodeInternal
 		return
 	}
 
@@ -90,8 +90,8 @@ func (tx *SendTx) GetSigner() []btypes.Address {
 	return []btypes.Address{tx.From}
 }
 
-func (tx *SendTx) CalcGas() btypes.BigInt {
-	return btypes.ZeroInt()
+func (tx *SendTx) CalcGas() btypes.Uint {
+	return btypes.ZeroUint()
 }
 
 func (tx *SendTx) GetGasPayer() btypes.Address {

--- a/example/kvstore/cmd/kvstorecli/main.go
+++ b/example/kvstore/cmd/kvstorecli/main.go
@@ -88,5 +88,5 @@ func sendKVTx(k, v, chainID string, http *client.HTTP, cdc *go_amino.Codec) {
 
 func wrapToStdTx(key, value, chainID string) *txs.TxStd {
 	kv := kvstore.NewKvstoreTx([]byte(key), []byte(value))
-	return txs.NewTxStd(kv, chainID, types.NewInt(int64(10000)))
+	return txs.NewTxStd(kv, chainID, types.NewUint(uint64(10000)))
 }

--- a/example/kvstore/tx.go
+++ b/example/kvstore/tx.go
@@ -43,17 +43,17 @@ func (kv KvstoreTx) Exec(ctx context.Context) (result types.Result, crossTxQcps 
 	accMapper := baseabci.GetAccountMapper(ctx)
 	qcpMapper := baseabci.GetQcpMapper(ctx)
 
-	logger.Info("kvMapper", kvMapper)
-	logger.Info("qcpMapper", qcpMapper)
-	logger.Info("accMapper", accMapper)
+	logger.Info("mapper", "kvMapper", kvMapper)
+	logger.Info("mapper", "qcpMapper", qcpMapper)
+	logger.Info("mapper", "accMapper", accMapper)
 
 	key := string(kv.Key)
 	value := kvMapper.GetKey(key)
-	logger.Info("origin is: ", key, "=", value)
+	logger.Info("before", "origin is: ", key, "=", value)
 
 	kvMapper.SaveKV(key, string(kv.Value))
 	value = kvMapper.GetKey(key)
-	logger.Info("after is: ", key, value)
+	logger.Info("after", "after is: ", key, "=", value)
 
 	return
 }
@@ -62,8 +62,8 @@ func (kv KvstoreTx) GetSigner() []types.Address {
 	return nil
 }
 
-func (kv KvstoreTx) CalcGas() types.BigInt {
-	return types.ZeroInt()
+func (kv KvstoreTx) CalcGas() types.Uint {
+	return types.ZeroUint()
 }
 
 func (kv KvstoreTx) GetGasPayer() types.Address {

--- a/go.mod
+++ b/go.mod
@@ -1,57 +1,57 @@
 module github.com/QOSGroup/qbase
 
 require (
-	github.com/BurntSushi/toml v0.3.0 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
-	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/bgentry/speakeasy v0.1.0
 	github.com/btcsuite/btcd v0.0.0-20180924021209-2a560b2036be
 	github.com/btcsuite/btcutil v0.0.0-20180706230648-ab6388e0c60a // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/ebuchman/fail-test v0.0.0-20170303061230-95f809107225 // indirect
-	github.com/fortytw2/leaktest v1.2.0 // indirect
-	github.com/go-kit/kit v0.7.0 // indirect
-	github.com/go-logfmt/logfmt v0.3.0 // indirect
+	github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d // indirect
+	github.com/fortytw2/leaktest v1.3.0 // indirect
+	github.com/go-kit/kit v0.8.0 // indirect
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gogo/protobuf v1.1.1 // indirect
 	github.com/golang/protobuf v1.2.0
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
-	github.com/gorilla/websocket v1.2.0 // indirect
-	github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce // indirect
+	github.com/gorilla/websocket v1.4.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmhodges/levigo v0.0.0-20161115193449-c42d9e0ca023 // indirect
-	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
 	github.com/magiconair/properties v1.8.0 // indirect
 	github.com/mattn/go-isatty v0.0.4
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/mitchellh/mapstructure v0.0.0-20180715050151-f15292f7a699 // indirect
-	github.com/onsi/gomega v1.4.2 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/onsi/ginkgo v1.7.0 // indirect
+	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
 	github.com/pkg/errors v0.8.0
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v0.0.0-20180709125804-ae27198cdd90 // indirect
+	github.com/prometheus/client_golang v0.9.1 // indirect
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910 // indirect
-	github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e // indirect
-	github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273 // indirect
-	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165 // indirect
-	github.com/spf13/afero v1.1.1 // indirect
-	github.com/spf13/cast v1.2.0 // indirect
+	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275 // indirect
+	github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a // indirect
+	github.com/rs/cors v1.6.0 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/cobra v0.0.1
-	github.com/spf13/jwalterweatherman v0.0.0-20180814060501-14d3d4c51834 // indirect
-	github.com/spf13/pflag v1.0.1
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.2
 	github.com/spf13/viper v1.0.0
 	github.com/stretchr/testify v1.2.2
-	github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d // indirect
+	github.com/syndtr/goleveldb v0.0.0-20181128100959-b001fa50d6b2 // indirect
+	github.com/tendermint/btcd v0.0.0-20180816174608-e5840949ff4f // indirect
 	github.com/tendermint/crypto v0.0.0-20180820045704-3764759f34a5
-	github.com/tendermint/ed25519 v0.0.0-20171027050219-d8387025d2b9 // indirect
-	github.com/tendermint/go-amino v0.12.0
-	github.com/tendermint/iavl v0.11.0
-	github.com/tendermint/tendermint v0.23.1
-	github.com/tendermint/tmlibs v0.9.0
+	github.com/tendermint/go-amino v0.14.1
+	github.com/tendermint/iavl v0.12.0
+	github.com/tendermint/tendermint v0.27.0-dev1
 	github.com/tyler-smith/go-bip39 v1.0.0
-	golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941 // indirect
-	golang.org/x/net v0.0.0-20181005035420-146acd28ed58 // indirect
-	google.golang.org/grpc v1.15.0 // indirect
+	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 // indirect
+	golang.org/x/net v0.0.0-20181201002055-351d144fa1fc // indirect
+	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
+	golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35 // indirect
+	google.golang.org/grpc v1.17.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/keys/keybase.go
+++ b/keys/keybase.go
@@ -200,7 +200,7 @@ func (kb Keybase) Sign(name, passphrase string, msg []byte) (sig []byte, pub cry
 		if err != nil {
 			return nil, nil, err
 		}
-		kb.cdc.MustUnmarshalBinary([]byte(signed), sig)
+		kb.cdc.MustUnmarshalBinaryLengthPrefixed([]byte(signed), sig)
 		return sig, linfo.GetPubKey(), nil
 	}
 	sig, err = priv.Sign(msg)
@@ -575,11 +575,11 @@ func (i offlineInfo) GetAddress() types.Address {
 
 // encoding info
 func writeInfo(cdc *go_amino.Codec, i Info) []byte {
-	return cdc.MustMarshalBinary(i)
+	return cdc.MustMarshalBinaryLengthPrefixed(i)
 }
 
 // decoding info
 func readInfo(cdc *go_amino.Codec, bz []byte) (info Info, err error) {
-	err = cdc.UnmarshalBinary(bz, &info)
+	err = cdc.UnmarshalBinaryLengthPrefixed(bz, &info)
 	return
 }

--- a/qcp/qcpmapper.go
+++ b/qcp/qcpmapper.go
@@ -29,7 +29,7 @@ func BuildOutSequenceKey(outChainID string) []byte {
 	return []byte(fmt.Sprintf(outSequenceKey, outChainID))
 }
 
-func BuildOutSequenceTxKey(outChainID string, sequence int64) []byte {
+func BuildOutSequenceTxKey(outChainID string, sequence uint64) []byte {
 	return []byte(fmt.Sprintf(outSequenceTxKey, outChainID, sequence))
 }
 
@@ -70,31 +70,31 @@ func (mapper *QcpMapper) SetChainInTrustPubKey(inChain string, pubkey crypto.Pub
 	mapper.Set(BuildInPubkeyKey(inChain), pubkey)
 }
 
-func (mapper *QcpMapper) GetMaxChainOutSequence(outChain string) (seq int64) {
+func (mapper *QcpMapper) GetMaxChainOutSequence(outChain string) (seq uint64) {
 	mapper.Get(BuildOutSequenceKey(outChain), &seq)
 	return
 }
 
-func (mapper *QcpMapper) SetMaxChainOutSequence(outChain string, sequence int64) {
+func (mapper *QcpMapper) SetMaxChainOutSequence(outChain string, sequence uint64) {
 	mapper.Set(BuildOutSequenceKey(outChain), sequence)
 }
 
-func (mapper *QcpMapper) GetChainOutTxs(outChain string, sequence int64) *txs.TxQcp {
+func (mapper *QcpMapper) GetChainOutTxs(outChain string, sequence uint64) *txs.TxQcp {
 	var txQcp txs.TxQcp
 	mapper.Get(BuildOutSequenceTxKey(outChain, sequence), &txQcp)
 	return &txQcp
 }
 
-func (mapper *QcpMapper) SetChainOutTxs(outChain string, sequence int64, txQcp *txs.TxQcp) {
+func (mapper *QcpMapper) SetChainOutTxs(outChain string, sequence uint64, txQcp *txs.TxQcp) {
 	mapper.Set(BuildOutSequenceTxKey(outChain, sequence), *txQcp)
 }
 
-func (mapper *QcpMapper) GetMaxChainInSequence(inChain string) (seq int64) {
+func (mapper *QcpMapper) GetMaxChainInSequence(inChain string) (seq uint64) {
 	mapper.Get(BuildInSequenceKey(inChain), &seq)
 	return
 }
 
-func (mapper *QcpMapper) SetMaxChainInSequence(inChain string, sequence int64) {
+func (mapper *QcpMapper) SetMaxChainInSequence(inChain string, sequence uint64) {
 	mapper.Set(BuildInSequenceKey(inChain), sequence)
 }
 

--- a/qcp/qcpmapper_test.go
+++ b/qcp/qcpmapper_test.go
@@ -34,11 +34,11 @@ func Test_qcpMapper_GetMaxChainOutSequence(t *testing.T) {
 	qcpMapper, _ = ctx.Mapper(qcpMapper.MapperName()).(*QcpMapper)
 
 	outChain := "qsc"
-	seq := int64(12)
-	cseq := int64(13)
+	seq := uint64(12)
+	cseq := uint64(13)
 
 	maxSeq := qcpMapper.GetMaxChainOutSequence(outChain)
-	require.Equal(t, int64(0), maxSeq)
+	require.Equal(t, uint64(0), maxSeq)
 
 	qcpMapper.SetMaxChainOutSequence(outChain, seq)
 	maxSeq = qcpMapper.GetMaxChainOutSequence(outChain)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1,14 +1,51 @@
 package config
 
+import (
+	"fmt"
+
+	"github.com/QOSGroup/qbase/types"
+)
+
 //_____________________________________________________________________
 
 // Configuration structure for command functions that share configuration.
 // For example: init, init gen-tx and testnet commands need similar input and run the same code
 
 // Storage for init gen-tx command input parameters
+
+const (
+	defaultMinimumFees = ""
+)
+
 type GenTx struct {
 	Name      string
 	CliRoot   string
 	Overwrite bool
 	IP        string
 }
+
+// BaseConfig defines the server's basic configuration
+type BaseConfig struct {
+	// Tx minimum fee
+	MinFees string `mapstructure:"minimum_fees"`
+}
+
+// Config defines the server's top level configuration
+type Config struct {
+	BaseConfig `mapstructure:",squash"`
+}
+
+// SetMinimumFee sets the minimum fee.
+func (c *Config) SetMinimumFees(fees types.BaseCoins) { c.MinFees = fees.String() }
+
+// SetMinimumFee sets the minimum fee.
+func (c *Config) MinimumFees() types.BaseCoins {
+	fees, err := types.ParseCoins(c.MinFees)
+	if err != nil {
+		panic(fmt.Sprintf("invalid minimum fees: %v", err))
+	}
+	return fees
+}
+
+// DefaultConfig returns server's default configuration.
+func DefaultConfig() *Config { return &Config{BaseConfig{MinFees: defaultMinimumFees}} }

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/spf13/viper"
+	cmn "github.com/tendermint/tendermint/libs/common"
+)
+
+const defaultConfigTemplate = `# This is a TOML config file.
+# For more information, see https://github.com/toml-lang/toml
+
+##### main base config options #####
+
+# Validators reject any tx from the mempool with less than the minimum fee per gas.
+minimum_fees = "{{ .BaseConfig.MinFees }}"
+`
+
+var configTemplate *template.Template
+
+func init() {
+	var err error
+	tmpl := template.New("configFileTemplate")
+	if configTemplate, err = tmpl.Parse(defaultConfigTemplate); err != nil {
+		panic(err)
+	}
+}
+
+// ParseConfig retrieves the default environment configuration for config.
+func ParseConfig() (*Config, error) {
+	conf := DefaultConfig()
+	err := viper.Unmarshal(conf)
+	return conf, err
+}
+
+// WriteConfigFile renders config using the template and writes it to configFilePath.
+func WriteConfigFile(configFilePath string, config *Config) {
+	var buffer bytes.Buffer
+
+	if err := configTemplate.Execute(&buffer, config); err != nil {
+		panic(err)
+	}
+
+	cmn.MustWriteFile(configFilePath, buffer.Bytes(), 0644)
+}

--- a/server/constructors.go
+++ b/server/constructors.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -8,41 +9,33 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
+	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 type (
-	// AppCreator reflects a function that allows us to lazily initialize an
+	// AppCreator is a function that allows us to lazily initialize an
 	// application using various configurations.
-	AppCreator func(home string, logger log.Logger, traceStore string) (abci.Application, error)
+	AppCreator func(log.Logger, dbm.DB, io.Writer) abci.Application
 
-	// AppCreatorInit reflects a function that performs initialization of an
-	// AppCreator.
-	AppCreatorInit func(log.Logger, dbm.DB, io.Writer) abci.Application
+	// AppExporter is a function that dumps all app state to
+	// JSON-serializable structure and returns the current validator set.
+	AppExporter func(log.Logger, dbm.DB, io.Writer, int64, bool) (json.RawMessage, []tmtypes.GenesisValidator, error)
 )
 
-// ConstructAppCreator returns an application generation function.
-func ConstructAppCreator(appFn AppCreatorInit, name string) AppCreator {
-	return func(rootDir string, logger log.Logger, traceStore string) (abci.Application, error) {
-		dataDir := filepath.Join(rootDir, "data")
+func openDB(rootDir string) (dbm.DB, error) {
+	dataDir := filepath.Join(rootDir, "data")
+	db, err := dbm.NewGoLevelDB("application", dataDir)
+	return db, err
+}
 
-		db, err := dbm.NewGoLevelDB(name, dataDir)
-		if err != nil {
-			return nil, err
-		}
-
-		var traceStoreWriter io.Writer
-		if traceStore != "" {
-			traceStoreWriter, err = os.OpenFile(
-				traceStore,
-				os.O_WRONLY|os.O_APPEND|os.O_CREATE,
-				0666,
-			)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		app := appFn(logger, db, traceStoreWriter)
-		return app, nil
+func openTraceWriter(traceWriterFile string) (w io.Writer, err error) {
+	if traceWriterFile != "" {
+		w, err = os.OpenFile(
+			traceWriterFile,
+			os.O_WRONLY|os.O_APPEND|os.O_CREATE,
+			0666,
+		)
+		return
 	}
+	return
 }

--- a/server/init.go
+++ b/server/init.go
@@ -69,7 +69,7 @@ func GenTxCmd(ctx *Context, cdc *Codec, appInit AppInit) *cobra.Command {
 
 			ip := viper.GetString(FlagIP)
 			if len(ip) == 0 {
-				eip, err := externalIP()
+				eip, err := ExternalIP()
 				if err != nil {
 					return err
 				}
@@ -196,6 +196,7 @@ func InitCmd(ctx *Context, cdc *Codec, appInit AppInit) *cobra.Command {
 	cmd.Flags().AddFlagSet(appInit.FlagsAppGenState)
 	cmd.Flags().AddFlagSet(appInit.FlagsAppGenTx) // need to add this flagset for when no GenTx's provided
 	cmd.AddCommand(GenTxCmd(ctx, cdc, appInit))
+	cmd.MarkFlagRequired(FlagName)
 	return cmd
 }
 

--- a/server/tm_cmds.go
+++ b/server/tm_cmds.go
@@ -2,13 +2,14 @@ package server
 
 import (
 	"fmt"
-	"github.com/QOSGroup/qbase/types"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	tcmd "github.com/tendermint/tendermint/cmd/tendermint/commands"
 	"github.com/tendermint/tendermint/p2p"
 	pvm "github.com/tendermint/tendermint/privval"
+	"github.com/tendermint/tendermint/types"
 )
 
 const (
@@ -47,10 +48,16 @@ func ShowValidatorCmd(ctx *Context) *cobra.Command {
 				return printlnJSON(valPubKey)
 			}
 
+			cdc := New()
+			bz, err := cdc.MarshalJSON(valPubKey)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(bz))
 			return nil
 		},
 	}
-	cmd.Flags().Bool(FlagJson, true, "get machine parseable output")
+	cmd.Flags().Bool(FlagJson, false, "get machine parseable output")
 	return &cmd
 }
 
@@ -58,17 +65,17 @@ func ShowValidatorCmd(ctx *Context) *cobra.Command {
 func ShowAddressCmd(ctx *Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show-address",
-		Short: "Shows this node's tendermint validator address",
+		Short: "Shows this node's tendermint validator consensus address",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := ctx.Config
 			privValidator := pvm.LoadOrGenFilePV(cfg.PrivValidatorFile())
-			valAddr := (types.Address)(privValidator.Address)
+			valConsAddr := (types.Address)(privValidator.Address)
 
 			if viper.GetBool(FlagJson) {
-				return printlnJSON(valAddr)
+				return printlnJSON(valConsAddr)
 			}
 
-			fmt.Println(valAddr.String())
+			fmt.Println(valConsAddr.String())
 			return nil
 		},
 	}

--- a/store/basemultistore.go
+++ b/store/basemultistore.go
@@ -5,11 +5,12 @@ import (
 	"io"
 	"strings"
 
-	"github.com/QOSGroup/qbase/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/merkle"
 	"github.com/tendermint/tendermint/crypto/tmhash"
 	dbm "github.com/tendermint/tendermint/libs/db"
+
+	sdk "github.com/QOSGroup/qbase/types"
 )
 
 const (
@@ -229,13 +230,19 @@ func (rs *baseMultiStore) CacheMultiStore() CacheMultiStore {
 }
 
 // Implements MultiStore.
+// If the store does not exist, panics.
 func (rs *baseMultiStore) GetStore(key StoreKey) Store {
-	return rs.stores[key]
+	store := rs.stores[key]
+	if store == nil {
+		panic("Could not load store " + key.String())
+	}
+	return store
 }
 
 // GetKVStore implements the MultiStore interface. If tracing is enabled on the
 // baseMultiStore, a wrapped TraceKVStore will be returned with the given
 // tracer, otherwise, the original KVStore will be returned.
+// If the store does not exist, panics.
 func (rs *baseMultiStore) GetKVStore(key StoreKey) KVStore {
 	store := rs.stores[key].(KVStore)
 
@@ -278,12 +285,12 @@ func (rs *baseMultiStore) Query(req abci.RequestQuery) abci.ResponseQuery {
 	store := rs.getStoreByName(storeName)
 	if store == nil {
 		msg := fmt.Sprintf("no such store: %s", storeName)
-		return types.ErrUnknownRequest(msg).QueryResult()
+		return sdk.ErrUnknownRequest(msg).QueryResult()
 	}
 	queryable, ok := store.(Queryable)
 	if !ok {
 		msg := fmt.Sprintf("store %s doesn't support queries", storeName)
-		return types.ErrUnknownRequest(msg).QueryResult()
+		return sdk.ErrUnknownRequest(msg).QueryResult()
 	}
 
 	// trim the path and make the query
@@ -294,31 +301,42 @@ func (rs *baseMultiStore) Query(req abci.RequestQuery) abci.ResponseQuery {
 		return res
 	}
 
+	if res.Proof == nil || len(res.Proof.Ops) == 0 {
+		return sdk.ErrInternal("substore proof was nil/empty when it should never be").QueryResult()
+	}
+
 	commitInfo, errMsg := getCommitInfo(rs.db, res.Height)
 	if errMsg != nil {
-		return types.ErrInternal(errMsg.Error()).QueryResult()
+		return sdk.ErrInternal(errMsg.Error()).QueryResult()
 	}
 
-	if res.Proof != nil {
-		res.Proof = buildMultiStoreProof(res.Proof, storeName, commitInfo.StoreInfos)
-	}
+	// Restore origin path and append proof op.
+	res.Proof.Ops = append(res.Proof.Ops, NewMultiStoreProofOp(
+		[]byte(storeName),
+		NewMultiStoreProof(commitInfo.StoreInfos),
+	).ProofOp())
 
+	// TODO: handle in another TM v0.26 update PR
+	// res.Proof = buildMultiStoreProof(res.Proof, storeName, commitInfo.StoreInfos)
 	return res
 }
 
 // parsePath expects a format like /<storeName>[/<subpath>]
 // Must start with /, subpath may be empty
 // Returns error if it doesn't start with /
-func parsePath(path string) (storeName string, subpath string, err types.Error) {
+func parsePath(path string) (storeName string, subpath string, err sdk.Error) {
 	if !strings.HasPrefix(path, "/") {
-		err = types.ErrUnknownRequest(fmt.Sprintf("invalid path: %s", path))
+		err = sdk.ErrUnknownRequest(fmt.Sprintf("invalid path: %s", path))
 		return
 	}
+
 	paths := strings.SplitN(path[1:], "/", 2)
 	storeName = paths[0]
+
 	if len(paths) == 2 {
 		subpath = "/" + paths[1]
 	}
+
 	return
 }
 
@@ -340,7 +358,8 @@ func (rs *baseMultiStore) loadCommitStoreFromParams(key StoreKey, id CommitID, p
 		store, err = LoadIAVLStore(db, id, rs.pruning)
 		return
 	case StoreTypeDB:
-		panic("dbm.DB is not a CommitStore")
+		store = commitDBStoreAdapter{dbStoreAdapter{db}}
+		return
 	case StoreTypeTransient:
 		_, ok := key.(*TransientStoreKey)
 		if !ok {
@@ -377,6 +396,7 @@ type storeParams struct {
 
 // NOTE: Keep commitInfo a simple immutable struct.
 type commitInfo struct {
+
 	// Version
 	Version int64
 
@@ -386,11 +406,12 @@ type commitInfo struct {
 
 // Hash returns the simple merkle root hash of the stores sorted by name.
 func (ci commitInfo) Hash() []byte {
-	// TODO cache to ci.hash []byte
-	m := make(map[string]merkle.Hasher, len(ci.StoreInfos))
+	// TODO: cache to ci.hash []byte
+	m := make(map[string][]byte, len(ci.StoreInfos))
 	for _, storeInfo := range ci.StoreInfos {
-		m[storeInfo.Name] = storeInfo
+		m[storeInfo.Name] = storeInfo.Hash()
 	}
+
 	return merkle.SimpleHashFromMap(m)
 }
 
@@ -422,13 +443,15 @@ type storeCore struct {
 func (si storeInfo) Hash() []byte {
 	// Doesn't write Name, since merkle.SimpleHashFromMap() will
 	// include them via the keys.
-	bz, _ := cdc.MarshalBinary(si.Core) // Does not error
+	bz, _ := cdc.MarshalBinaryLengthPrefixed(si.Core)
 	hasher := tmhash.New()
+
 	_, err := hasher.Write(bz)
 	if err != nil {
 		// TODO: Handle with #870
 		panic(err)
 	}
+
 	return hasher.Sum(nil)
 }
 
@@ -441,16 +464,18 @@ func getLatestVersion(db dbm.DB) int64 {
 	if latestBytes == nil {
 		return 0
 	}
-	err := cdc.UnmarshalBinary(latestBytes, &latest)
+
+	err := cdc.UnmarshalBinaryLengthPrefixed(latestBytes, &latest)
 	if err != nil {
 		panic(err)
 	}
+
 	return latest
 }
 
 // Set the latest version.
 func setLatestVersion(batch dbm.Batch, version int64) {
-	latestBytes, _ := cdc.MarshalBinary(version) // Does not error
+	latestBytes, _ := cdc.MarshalBinaryLengthPrefixed(version)
 	batch.Set([]byte(latestVersionKey), latestBytes)
 }
 
@@ -483,6 +508,7 @@ func commitStores(version int64, storeMap map[StoreKey]CommitStore) commitInfo {
 
 // Gets commitInfo from disk.
 func getCommitInfo(db dbm.DB, ver int64) (commitInfo, error) {
+
 	// Get from DB.
 	cInfoKey := fmt.Sprintf(commitInfoKeyFmt, ver)
 	cInfoBytes := db.Get([]byte(cInfoKey))
@@ -490,21 +516,19 @@ func getCommitInfo(db dbm.DB, ver int64) (commitInfo, error) {
 		return commitInfo{}, fmt.Errorf("failed to get baseMultiStore: no data")
 	}
 
-	// Parse bytes.
 	var cInfo commitInfo
-	err := cdc.UnmarshalBinary(cInfoBytes, &cInfo)
+
+	err := cdc.UnmarshalBinaryLengthPrefixed(cInfoBytes, &cInfo)
 	if err != nil {
 		return commitInfo{}, fmt.Errorf("failed to get baseMultiStore: %v", err)
 	}
+
 	return cInfo, nil
 }
 
 // Set a commitInfo for given version.
 func setCommitInfo(batch dbm.Batch, version int64, cInfo commitInfo) {
-	cInfoBytes, err := cdc.MarshalBinary(cInfo)
-	if err != nil {
-		panic(err)
-	}
+	cInfoBytes := cdc.MustMarshalBinaryLengthPrefixed(cInfo)
 	cInfoKey := fmt.Sprintf(commitInfoKeyFmt, version)
 	batch.Set([]byte(cInfoKey), cInfoBytes)
 }

--- a/store/dbstoreadapter.go
+++ b/store/dbstoreadapter.go
@@ -31,10 +31,30 @@ func (dsa dbStoreAdapter) Prefix(prefix []byte) KVStore {
 	return prefixStore{dsa, prefix}
 }
 
-// Implements KVStore
-//func (dsa dbStoreAdapter) Gas(meter types.GasMeter, config types.GasConfig) KVStore {
-//	return NewGasKVStore(meter, config, dsa)
-//}
-
 // dbm.DB implements KVStore so we can CacheKVStore it.
 var _ KVStore = dbStoreAdapter{}
+
+//----------------------------------------
+// commitDBStoreWrapper should only be used for simulation/debugging,
+// as it doesn't compute any commit hash, and it cannot load older state.
+
+// Wrapper type for dbm.Db with implementation of KVStore
+type commitDBStoreAdapter struct {
+	dbStoreAdapter
+}
+
+func (cdsa commitDBStoreAdapter) Commit() CommitID {
+	return CommitID{
+		Version: -1,
+		Hash:    []byte("FAKE_HASH"),
+	}
+}
+
+func (cdsa commitDBStoreAdapter) LastCommitID() CommitID {
+	return CommitID{
+		Version: -1,
+		Hash:    []byte("FAKE_HASH"),
+	}
+}
+
+func (cdsa commitDBStoreAdapter) SetPruning(_ PruningStrategy) {}

--- a/store/gaskvstore.go
+++ b/store/gaskvstore.go
@@ -1,0 +1,184 @@
+package store
+
+import (
+	"io"
+
+	"github.com/QOSGroup/qbase/types"
+)
+
+var _ KVStore = &gasKVStore{}
+
+// gasKVStore applies gas tracking to an underlying KVStore. It implements the
+// KVStore interface.
+type gasKVStore struct {
+	gasMeter  types.GasMeter
+	gasConfig types.GasConfig
+	parent    KVStore
+}
+
+// NewGasKVStore returns a reference to a new GasKVStore.
+// nolint
+func NewGasKVStore(gasMeter types.GasMeter, gasConfig types.GasConfig, parent KVStore) *gasKVStore {
+	kvs := &gasKVStore{
+		gasMeter:  gasMeter,
+		gasConfig: gasConfig,
+		parent:    parent,
+	}
+	return kvs
+}
+
+// Implements Store.
+func (gs *gasKVStore) GetStoreType() StoreType {
+	return gs.parent.GetStoreType()
+}
+
+// Implements KVStore.
+func (gs *gasKVStore) Get(key []byte) (value []byte) {
+	gs.gasMeter.ConsumeGas(gs.gasConfig.ReadCostFlat, types.GasReadCostFlatDesc)
+	value = gs.parent.Get(key)
+
+	// TODO overflow-safe math?
+	gs.gasMeter.ConsumeGas(gs.gasConfig.ReadCostPerByte*types.Gas(len(value)), types.GasReadPerByteDesc)
+
+	return value
+}
+
+// Implements KVStore.
+func (gs *gasKVStore) Set(key []byte, value []byte) {
+	gs.gasMeter.ConsumeGas(gs.gasConfig.WriteCostFlat, types.GasWriteCostFlatDesc)
+	// TODO overflow-safe math?
+	gs.gasMeter.ConsumeGas(gs.gasConfig.WriteCostPerByte*types.Gas(len(value)), types.GasWritePerByteDesc)
+	gs.parent.Set(key, value)
+}
+
+// Implements KVStore.
+func (gs *gasKVStore) Has(key []byte) bool {
+	gs.gasMeter.ConsumeGas(gs.gasConfig.HasCost, types.GasHasDesc)
+	return gs.parent.Has(key)
+}
+
+// Implements KVStore.
+func (gs *gasKVStore) Delete(key []byte) {
+	// charge gas to prevent certain attack vectors even though space is being freed
+	gs.gasMeter.ConsumeGas(gs.gasConfig.DeleteCost, types.GasDeleteDesc)
+	gs.parent.Delete(key)
+}
+
+// Implements KVStore
+func (gs *gasKVStore) Prefix(prefix []byte) KVStore {
+	// Keep gasstore layer at the top
+	return &gasKVStore{
+		gasMeter:  gs.gasMeter,
+		gasConfig: gs.gasConfig,
+		parent:    prefixStore{gs.parent, prefix},
+	}
+}
+
+// Implements KVStore
+func (gs *gasKVStore) Gas(meter types.GasMeter, config types.GasConfig) KVStore {
+	return NewGasKVStore(meter, config, gs)
+}
+
+// Iterator implements the KVStore interface. It returns an iterator which
+// incurs a flat gas cost for seeking to the first key/value pair and a variable
+// gas cost based on the current value's length if the iterator is valid.
+func (gs *gasKVStore) Iterator(start, end []byte) Iterator {
+	return gs.iterator(start, end, true)
+}
+
+// ReverseIterator implements the KVStore interface. It returns a reverse
+// iterator which incurs a flat gas cost for seeking to the first key/value pair
+// and a variable gas cost based on the current value's length if the iterator
+// is valid.
+func (gs *gasKVStore) ReverseIterator(start, end []byte) Iterator {
+	return gs.iterator(start, end, false)
+}
+
+// Implements KVStore.
+func (gs *gasKVStore) CacheWrap() CacheWrap {
+	panic("cannot CacheWrap a GasKVStore")
+}
+
+// CacheWrapWithTrace implements the KVStore interface.
+func (gs *gasKVStore) CacheWrapWithTrace(_ io.Writer, _ TraceContext) CacheWrap {
+	panic("cannot CacheWrapWithTrace a GasKVStore")
+}
+
+func (gs *gasKVStore) iterator(start, end []byte, ascending bool) Iterator {
+	var parent Iterator
+	if ascending {
+		parent = gs.parent.Iterator(start, end)
+	} else {
+		parent = gs.parent.ReverseIterator(start, end)
+	}
+
+	gi := newGasIterator(gs.gasMeter, gs.gasConfig, parent)
+	if gi.Valid() {
+		gi.(*gasIterator).consumeSeekGas()
+	}
+
+	return gi
+}
+
+type gasIterator struct {
+	gasMeter  types.GasMeter
+	gasConfig types.GasConfig
+	parent    Iterator
+}
+
+func newGasIterator(gasMeter types.GasMeter, gasConfig types.GasConfig, parent Iterator) Iterator {
+	return &gasIterator{
+		gasMeter:  gasMeter,
+		gasConfig: gasConfig,
+		parent:    parent,
+	}
+}
+
+// Implements Iterator.
+func (gi *gasIterator) Domain() (start []byte, end []byte) {
+	return gi.parent.Domain()
+}
+
+// Implements Iterator.
+func (gi *gasIterator) Valid() bool {
+	return gi.parent.Valid()
+}
+
+// Next implements the Iterator interface. It seeks to the next key/value pair
+// in the iterator. It incurs a flat gas cost for seeking and a variable gas
+// cost based on the current value's length if the iterator is valid.
+func (gi *gasIterator) Next() {
+	if gi.Valid() {
+		gi.consumeSeekGas()
+	}
+
+	gi.parent.Next()
+}
+
+// Key implements the Iterator interface. It returns the current key and it does
+// not incur any gas cost.
+func (gi *gasIterator) Key() (key []byte) {
+	key = gi.parent.Key()
+	return key
+}
+
+// Value implements the Iterator interface. It returns the current value and it
+// does not incur any gas cost.
+func (gi *gasIterator) Value() (value []byte) {
+	value = gi.parent.Value()
+	return value
+}
+
+// Implements Iterator.
+func (gi *gasIterator) Close() {
+	gi.parent.Close()
+}
+
+// consumeSeekGas consumes a flat gas cost for seeking and a variable gas cost
+// based on the current value's length.
+func (gi *gasIterator) consumeSeekGas() {
+	value := gi.Value()
+
+	gi.gasMeter.ConsumeGas(gi.gasConfig.ValueCostPerByte*types.Gas(len(value)), types.GasValuePerByteDesc)
+	gi.gasMeter.ConsumeGas(gi.gasConfig.IterNextCostFlat, types.GasIterNextCostFlatDesc)
+}

--- a/store/memiterator.go
+++ b/store/memiterator.go
@@ -18,8 +18,7 @@ type memIterator struct {
 func newMemIterator(start, end []byte, items []cmn.KVPair) *memIterator {
 	itemsInDomain := make([]cmn.KVPair, 0)
 	for _, item := range items {
-		ascending := keyCompare(start, end) < 0
-		if dbm.IsKeyInDomain(item.Key, start, end, !ascending) {
+		if dbm.IsKeyInDomain(item.Key, start, end) {
 			itemsInDomain = append(itemsInDomain, item)
 		}
 	}

--- a/store/multistoreproof.go
+++ b/store/multistoreproof.go
@@ -2,90 +2,139 @@ package store
 
 import (
 	"bytes"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/tendermint/iavl"
+	"github.com/tendermint/tendermint/crypto/merkle"
 	cmn "github.com/tendermint/tendermint/libs/common"
 )
 
 // MultiStoreProof defines a collection of store proofs in a multi-store
 type MultiStoreProof struct {
 	StoreInfos []storeInfo
-	StoreName  string
-	RangeProof iavl.RangeProof
 }
 
-// buildMultiStoreProof build MultiStoreProof based on iavl proof and storeInfos
-func buildMultiStoreProof(iavlProof []byte, storeName string, storeInfos []storeInfo) []byte {
-	var rangeProof iavl.RangeProof
-	cdc.MustUnmarshalBinary(iavlProof, &rangeProof)
-
-	msp := MultiStoreProof{
-		StoreInfos: storeInfos,
-		StoreName:  storeName,
-		RangeProof: rangeProof,
-	}
-
-	proof := cdc.MustMarshalBinary(msp)
-	return proof
+func NewMultiStoreProof(storeInfos []storeInfo) *MultiStoreProof {
+	return &MultiStoreProof{StoreInfos: storeInfos}
 }
 
-// VerifyMultiStoreCommitInfo verify multiStoreCommitInfo against appHash
-func VerifyMultiStoreCommitInfo(storeName string, storeInfos []storeInfo, appHash []byte) ([]byte, error) {
-	var substoreCommitHash []byte
-	var height int64
-	for _, storeInfo := range storeInfos {
-		if storeInfo.Name == storeName {
-			substoreCommitHash = storeInfo.Core.CommitID.Hash
-			height = storeInfo.Core.CommitID.Version
-		}
-	}
-	if len(substoreCommitHash) == 0 {
-		return nil, cmn.NewError("failed to get substore root commit hash by store name")
-	}
-
+// ComputeRootHash returns the root hash for a given multi-store proof.
+func (proof *MultiStoreProof) ComputeRootHash() []byte {
 	ci := commitInfo{
-		Version:    height,
-		StoreInfos: storeInfos,
+		Version:    -1, // TODO: Not needed; improve code.
+		StoreInfos: proof.StoreInfos,
 	}
-	if !bytes.Equal(appHash, ci.Hash()) {
-		return nil, cmn.NewError("the merkle root of multiStoreCommitInfo doesn't equal to appHash")
-	}
-	return substoreCommitHash, nil
+	return ci.Hash()
 }
 
-// VerifyRangeProof verify iavl RangeProof
-func VerifyRangeProof(key, value []byte, substoreCommitHash []byte, rangeProof *iavl.RangeProof) error {
-
-	// verify the proof to ensure data integrity.
-	err := rangeProof.Verify(substoreCommitHash)
-	if err != nil {
-		return errors.Wrap(err, "proof root hash doesn't equal to substore commit root hash")
-	}
-
-	if len(value) != 0 {
-		// verify existence proof
-		err = rangeProof.VerifyItem(key, value)
-		if err != nil {
-			return errors.Wrap(err, "failed in existence verification")
-		}
-	} else {
-		// verify absence proof
-		err = rangeProof.VerifyAbsence(key)
-		if err != nil {
-			return errors.Wrap(err, "failed in absence verification")
-		}
-	}
-
-	return nil
-}
-
-// RequireProof return whether proof is require for the subpath
+// RequireProof returns whether proof is required for the subpath.
 func RequireProof(subpath string) bool {
-	// Currently, only when query subpath is "/store" or "/key", will proof be included in response.
-	// If there are some changes about proof building in iavlstore.go, we must change code here to keep consistency with iavlstore.go:212
-	if subpath == "/store" || subpath == "/key" {
+	// XXX: create a better convention.
+	// Currently, only when query subpath is "/key", will proof be included in
+	// response. If there are some changes about proof building in iavlstore.go,
+	// we must change code here to keep consistency with iavlStore#Query.
+	if subpath == "/key" {
 		return true
 	}
+
 	return false
+}
+
+//-----------------------------------------------------------------------------
+
+var _ merkle.ProofOperator = MultiStoreProofOp{}
+
+// the multi-store proof operation constant value
+const ProofOpMultiStore = "multistore"
+
+// TODO: document
+type MultiStoreProofOp struct {
+	// Encoded in ProofOp.Key
+	key []byte
+
+	// To encode in ProofOp.Data.
+	Proof *MultiStoreProof `json:"proof"`
+}
+
+func NewMultiStoreProofOp(key []byte, proof *MultiStoreProof) MultiStoreProofOp {
+	return MultiStoreProofOp{
+		key:   key,
+		Proof: proof,
+	}
+}
+
+// MultiStoreProofOpDecoder returns a multi-store merkle proof operator from a
+// given proof operation.
+func MultiStoreProofOpDecoder(pop merkle.ProofOp) (merkle.ProofOperator, error) {
+	if pop.Type != ProofOpMultiStore {
+		return nil, cmn.NewError("unexpected ProofOp.Type; got %v, want %v", pop.Type, ProofOpMultiStore)
+	}
+
+	// XXX: a bit strange as we'll discard this, but it works
+	var op MultiStoreProofOp
+
+	err := cdc.UnmarshalBinaryLengthPrefixed(pop.Data, &op)
+	if err != nil {
+		return nil, cmn.ErrorWrap(err, "decoding ProofOp.Data into MultiStoreProofOp")
+	}
+
+	return NewMultiStoreProofOp(pop.Key, op.Proof), nil
+}
+
+// ProofOp return a merkle proof operation from a given multi-store proof
+// operation.
+func (op MultiStoreProofOp) ProofOp() merkle.ProofOp {
+	bz := cdc.MustMarshalBinaryLengthPrefixed(op)
+	return merkle.ProofOp{
+		Type: ProofOpMultiStore,
+		Key:  op.key,
+		Data: bz,
+	}
+}
+
+// String implements the Stringer interface for a mult-store proof operation.
+func (op MultiStoreProofOp) String() string {
+	return fmt.Sprintf("MultiStoreProofOp{%v}", op.GetKey())
+}
+
+// GetKey returns the key for a multi-store proof operation.
+func (op MultiStoreProofOp) GetKey() []byte {
+	return op.key
+}
+
+// Run executes a multi-store proof operation for a given value. It returns
+// the root hash if the value matches all the store's commitID's hash or an
+// error otherwise.
+func (op MultiStoreProofOp) Run(args [][]byte) ([][]byte, error) {
+	if len(args) != 1 {
+		return nil, cmn.NewError("Value size is not 1")
+	}
+
+	value := args[0]
+	root := op.Proof.ComputeRootHash()
+
+	for _, si := range op.Proof.StoreInfos {
+		if si.Name == string(op.key) {
+			if bytes.Equal(value, si.Core.CommitID.Hash) {
+				return [][]byte{root}, nil
+			}
+
+			return nil, cmn.NewError("hash mismatch for substore %v: %X vs %X", si.Name, si.Core.CommitID.Hash, value)
+		}
+	}
+
+	return nil, cmn.NewError("key %v not found in multistore proof", op.key)
+}
+
+//-----------------------------------------------------------------------------
+
+// XXX: This should be managed by the rootMultiStore which may want to register
+// more proof ops?
+func DefaultProofRuntime() (prt *merkle.ProofRuntime) {
+	prt = merkle.NewProofRuntime()
+	prt.RegisterOpDecoder(merkle.ProofOpSimpleValue, merkle.SimpleValueOpDecoder)
+	prt.RegisterOpDecoder(iavl.ProofOpIAVLValue, iavl.IAVLValueOpDecoder)
+	prt.RegisterOpDecoder(iavl.ProofOpIAVLAbsence, iavl.IAVLAbsenceOpDecoder)
+	prt.RegisterOpDecoder(ProofOpMultiStore, MultiStoreProofOpDecoder)
+	return
 }

--- a/store/transientstore.go
+++ b/store/transientstore.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/QOSGroup/qbase/types"
 	dbm "github.com/tendermint/tendermint/libs/db"
 )
 
@@ -38,9 +39,9 @@ func (ts *transientStore) Prefix(prefix []byte) KVStore {
 }
 
 // Implements KVStore
-//func (ts *transientStore) Gas(meter types.GasMeter, config types.GasConfig) KVStore {
-//	return NewGasKVStore(meter, config, ts)
-//}
+func (ts *transientStore) Gas(meter types.GasMeter, config types.GasConfig) KVStore {
+	return NewGasKVStore(meter, config, ts)
+}
 
 // Implements Store.
 func (ts *transientStore) GetStoreType() StoreType {

--- a/txs/qcpresult.go
+++ b/txs/qcpresult.go
@@ -1,9 +1,6 @@
 package txs
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/QOSGroup/qbase/context"
 	"github.com/QOSGroup/qbase/types"
 	tcommon "github.com/tendermint/tendermint/libs/common"
@@ -12,7 +9,7 @@ import (
 // qos端对TxQcp的执行结果
 type QcpTxResult struct {
 	Result              types.Result `json:"result"`              //对应TxQcp执行结果
-	QcpOriginalSequence int64        `json:"qcporiginalsequence"` //此结果对应的TxQcp.Sequence
+	QcpOriginalSequence uint64       `json:"qcporiginalsequence"` //此结果对应的TxQcp.Sequence
 	QcpOriginalExtends  string       `json:"qcpextends"`          //此结果对应的 TxQcp.Extends
 	Info                string       `json:"info"`                //结果信息
 }
@@ -25,15 +22,6 @@ func (tx *QcpTxResult) IsOk() bool {
 
 // 功能：检测结构体字段的合法性
 func (tx *QcpTxResult) ValidateData(ctx context.Context) error {
-
-	if types.NewInt(tx.Result.GasUsed).LT(types.ZeroInt()) {
-		return errors.New("QcpTxResult's  GasUsed is less then zero")
-	}
-
-	if tx.QcpOriginalSequence <= 0 {
-		return fmt.Errorf("QcpTxResult's QcpOriginalSequence Illegal data, except bigger than 0 , actual: %d ", tx.QcpOriginalSequence)
-	}
-
 	return nil
 }
 
@@ -59,8 +47,8 @@ func (tx *QcpTxResult) GetSigner() []types.Address {
 
 // 功能：计算gas
 // 备注：暂返回0，后期可根据实际情况调整
-func (tx *QcpTxResult) CalcGas() types.BigInt {
-	return types.ZeroInt()
+func (tx *QcpTxResult) CalcGas() types.Uint {
+	return types.ZeroUint()
 }
 
 // 功能：获取gas付费人
@@ -71,7 +59,7 @@ func (tx *QcpTxResult) GetGasPayer() types.Address {
 
 // 获取签名字段
 func (tx *QcpTxResult) GetSignData() []byte {
-	ret := types.Int2Byte(int64(tx.Result.Code))
+	ret := types.Int2Byte(uint64(tx.Result.Code))
 	ret = append(ret, tx.Result.Data...)
 	ret = append(ret, Extends2Byte(tx.Result.Tags)...)
 	ret = append(ret, types.Int2Byte(tx.Result.GasUsed)...)
@@ -83,7 +71,7 @@ func (tx *QcpTxResult) GetSignData() []byte {
 }
 
 // 功能：构建 QcpTxReasult 结构体
-func NewQcpTxResult(result types.Result, qcpSequence int64, qcpExtends, info string) *QcpTxResult {
+func NewQcpTxResult(result types.Result, qcpSequence uint64, qcpExtends, info string) *QcpTxResult {
 	return &QcpTxResult{
 		Result:              result,
 		QcpOriginalSequence: qcpSequence,

--- a/txs/txqcp.go
+++ b/txs/txqcp.go
@@ -8,15 +8,15 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 )
 
-// 功能：
+// 功能： QCP协议数据结构
 type TxQcp struct {
 	TxStd       *TxStd    `json:"txstd"`       //TxStd结构
-	From        string    `json:"from"`        //qscName
-	To          string    `json:"to"`          //qosName
-	Sequence    int64     `json:"sequence"`    //发送Sequence
+	From        string    `json:"from"`        //`From` chainID
+	To          string    `json:"to"`          //`To` chainID
+	Sequence    uint64    `json:"sequence"`    //发送Sequence
 	Sig         Signature `json:"sig"`         //签名
-	BlockHeight int64     `json:"blockheight"` //Tx所在block高度
-	TxIndex     int64     `json:"txindex"`     //Tx在block的位置
+	BlockHeight uint64    `json:"blockheight"` //Tx所在block高度
+	TxIndex     uint64    `json:"txindex"`     //Tx在block的位置
 	IsResult    bool      `json:"isresult"`    //是否为Result
 	Extends     string    `json:"extends"`     //扩展字段
 }
@@ -50,12 +50,12 @@ func (tx *TxQcp) BuildSignatureBytes() []byte {
 	return tx.getSigData()
 }
 
-func (tx *TxQcp) SignTx(prvkey crypto.PrivKey) (signedbyte []byte, err error) {
+func (tx *TxQcp) SignTx(privkey crypto.PrivKey) (signedbyte []byte, err error) {
 	data := tx.BuildSignatureBytes()
 	if data == nil {
 		return nil, errors.New("Signature txQcp err!")
 	}
-	signedbyte, err = prvkey.Sign(data)
+	signedbyte, err = privkey.Sign(data)
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +64,8 @@ func (tx *TxQcp) SignTx(prvkey crypto.PrivKey) (signedbyte []byte, err error) {
 }
 
 // 构建TxQCP结构体
-func NewTxQCP(txStd *TxStd, from string, to string, seqence int64,
-	blockheigh int64, txindex int64, isResult bool, extends string) (rTx *TxQcp) {
+func NewTxQCP(txStd *TxStd, from string, to string, seqence uint64,
+	blockheight uint64, txindex uint64, isResult bool, extends string) (rTx *TxQcp) {
 
 	rTx = &TxQcp{
 		txStd,
@@ -73,7 +73,7 @@ func NewTxQCP(txStd *TxStd, from string, to string, seqence int64,
 		to,
 		seqence,
 		Signature{},
-		blockheigh,
+		blockheight,
 		txindex,
 		isResult,
 		extends,

--- a/txs/txqcp_test.go
+++ b/txs/txqcp_test.go
@@ -35,7 +35,7 @@ func newQcpTxResult() (txqcpresult *QcpTxResult) {
 }
 
 func newTxStd(tx ITx) (txstd *TxStd) {
-	txstd = NewTxStd(tx, "qsc1", types.NewInt(100))
+	txstd = NewTxStd(tx, "qsc1", types.NewUint(100))
 	signer := txstd.ITx.GetSigner()
 
 	db := dbm.NewMemDB()
@@ -63,7 +63,7 @@ func newTxStd(tx ITx) (txstd *TxStd) {
 			return nil
 		}
 
-		signbyte, errsign := txstd.SignTx(prvKey, int64(nonce), ctx.ChainID())
+		signbyte, errsign := txstd.SignTx(prvKey, nonce, ctx.ChainID())
 		if signbyte == nil || errsign != nil {
 			return nil
 		}
@@ -71,7 +71,7 @@ func newTxStd(tx ITx) (txstd *TxStd) {
 		signdata := Signature{
 			prvKey.PubKey(),
 			signbyte,
-			int64(nonce),
+			nonce,
 		}
 
 		txstd.Signature = append(txstd.Signature, signdata)
@@ -87,7 +87,7 @@ func TestNewQcpTxResult(t *testing.T) {
 	txResult.GetSigner()
 	txResult.GetGasPayer()
 
-	gas := txResult.CalcGas().Int64() < 0
+	gas := txResult.CalcGas().Uint64() < 0
 	require.Equal(t, gas, false)
 }
 

--- a/types/coin.go
+++ b/types/coin.go
@@ -2,7 +2,9 @@ package types
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -340,4 +342,35 @@ var _ sort.Interface = BaseCoins{}
 func (coins BaseCoins) Sort() BaseCoins {
 	sort.Sort(coins)
 	return coins
+}
+
+func ParseCoins(str string) ([]*BaseCoin, error) {
+	if len(str) == 0 {
+		return nil, nil
+	}
+	reDnm := `[[:alpha:]][[:alnum:]]{2,15}`
+	reAmt := `[[:digit:]]+`
+	reSpc := `[[:space:]]*`
+	reCoin := regexp.MustCompile(fmt.Sprintf(`^(%s)%s(%s)$`, reAmt, reSpc, reDnm))
+
+	var coins []*BaseCoin
+	arr := strings.Split(str, ",")
+	for _, q := range arr {
+		coin := reCoin.FindStringSubmatch(q)
+		if len(coin) != 3 {
+			return coins, fmt.Errorf("coins str: %s parse faild", q)
+		}
+		coin[2] = strings.TrimSpace(coin[2])
+		amount, err := strconv.ParseInt(strings.TrimSpace(coin[1]), 10, 64)
+		if err != nil {
+			return coins, err
+		}
+
+		coins = append(coins, &BaseCoin{
+			coin[2],
+			NewInt(amount),
+		})
+	}
+
+	return coins, nil
 }

--- a/types/gas.go
+++ b/types/gas.go
@@ -1,17 +1,44 @@
 package types
 
-// Gas measured by the SDK
-type Gas = int64
+// Gas consumption descriptors.
+const (
+	GasIterNextCostFlatDesc = "IterNextFlat"
+	GasValuePerByteDesc     = "ValuePerByte"
+	GasWritePerByteDesc     = "WritePerByte"
+	GasReadPerByteDesc      = "ReadPerByte"
+	GasWriteCostFlatDesc    = "WriteFlat"
+	GasReadCostFlatDesc     = "ReadFlat"
+	GasHasDesc              = "Has"
+	GasDeleteDesc           = "Delete"
+)
 
-// Error thrown when out of gas
+var (
+	cachedKVGasConfig        = KVGasConfig()
+	cachedTransientGasConfig = TransientGasConfig()
+)
+
+// Gas measured by the SDK
+type Gas = uint64
+
+// ErrorOutOfGas defines an error thrown when an action results in out of gas.
 type ErrorOutOfGas struct {
+	Descriptor string
+}
+
+// ErrorGasOverflow defines an error thrown when an action results gas consumption
+// unsigned integer overflow.
+type ErrorGasOverflow struct {
 	Descriptor string
 }
 
 // GasMeter interface to track gas consumption
 type GasMeter interface {
 	GasConsumed() Gas
+	GasConsumedToLimit() Gas
+	Limit() Gas
 	ConsumeGas(amount Gas, descriptor string)
+	IsPastLimit() bool
+	IsOutOfGas() bool
 }
 
 type basicGasMeter struct {
@@ -19,6 +46,7 @@ type basicGasMeter struct {
 	consumed Gas
 }
 
+// NewGasMeter returns a reference to a new basicGasMeter.
 func NewGasMeter(limit Gas) GasMeter {
 	return &basicGasMeter{
 		limit:    limit,
@@ -30,17 +58,44 @@ func (g *basicGasMeter) GasConsumed() Gas {
 	return g.consumed
 }
 
+func (g *basicGasMeter) Limit() Gas {
+	return g.limit
+}
+
+func (g *basicGasMeter) GasConsumedToLimit() Gas {
+	if g.IsPastLimit() {
+		return g.limit
+	}
+	return g.consumed
+}
+
 func (g *basicGasMeter) ConsumeGas(amount Gas, descriptor string) {
-	g.consumed += amount
+	var overflow bool
+
+	// TODO: Should we set the consumed field after overflow checking?
+	g.consumed, overflow = AddUint64Overflow(g.consumed, amount)
+	if overflow {
+		panic(ErrorGasOverflow{descriptor})
+	}
+
 	if g.consumed > g.limit {
 		panic(ErrorOutOfGas{descriptor})
 	}
+}
+
+func (g *basicGasMeter) IsPastLimit() bool {
+	return g.consumed > g.limit
+}
+
+func (g *basicGasMeter) IsOutOfGas() bool {
+	return g.consumed >= g.limit
 }
 
 type infiniteGasMeter struct {
 	consumed Gas
 }
 
+// NewInfiniteGasMeter returns a reference to a new infiniteGasMeter.
 func NewInfiniteGasMeter() GasMeter {
 	return &infiniteGasMeter{
 		consumed: 0,
@@ -51,43 +106,60 @@ func (g *infiniteGasMeter) GasConsumed() Gas {
 	return g.consumed
 }
 
+func (g *infiniteGasMeter) GasConsumedToLimit() Gas {
+	return g.consumed
+}
+
+func (g *infiniteGasMeter) Limit() Gas {
+	return 0
+}
+
 func (g *infiniteGasMeter) ConsumeGas(amount Gas, descriptor string) {
-	g.consumed += amount
+	var overflow bool
+
+	// TODO: Should we set the consumed field after overflow checking?
+	g.consumed, overflow = AddUint64Overflow(g.consumed, amount)
+	if overflow {
+		panic(ErrorGasOverflow{descriptor})
+	}
+}
+
+func (g *infiniteGasMeter) IsPastLimit() bool {
+	return false
+}
+
+func (g *infiniteGasMeter) IsOutOfGas() bool {
+	return false
 }
 
 // GasConfig defines gas cost for each operation on KVStores
 type GasConfig struct {
 	HasCost          Gas
+	DeleteCost       Gas
 	ReadCostFlat     Gas
 	ReadCostPerByte  Gas
 	WriteCostFlat    Gas
 	WriteCostPerByte Gas
-	KeyCostFlat      Gas
-	ValueCostFlat    Gas
 	ValueCostPerByte Gas
+	IterNextCostFlat Gas
 }
 
-var (
-	CachedDefaultGasConfig   = DefaultGasConfig()
-	CachedTransientGasConfig = TransientGasConfig()
-)
-
-// Default gas config for KVStores
-func DefaultGasConfig() GasConfig {
+// KVGasConfig returns a default gas config for KVStores.
+func KVGasConfig() GasConfig {
 	return GasConfig{
 		HasCost:          10,
+		DeleteCost:       10,
 		ReadCostFlat:     10,
 		ReadCostPerByte:  1,
 		WriteCostFlat:    10,
 		WriteCostPerByte: 10,
-		KeyCostFlat:      5,
-		ValueCostFlat:    10,
 		ValueCostPerByte: 1,
+		IterNextCostFlat: 15,
 	}
 }
 
-// Default gas config for TransientStores
+// TransientGasConfig returns a default gas config for TransientStores.
 func TransientGasConfig() GasConfig {
 	// TODO: define gasconfig for transient stores
-	return DefaultGasConfig()
+	return KVGasConfig()
 }

--- a/types/int.go
+++ b/types/int.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"encoding/json"
+	"math"
+	"testing"
 
 	"math/big"
 	"math/rand"
@@ -391,6 +393,17 @@ func (i Uint) IsUint64() bool {
 	return i.i.IsUint64()
 }
 
+func (i Uint) IsNil() bool {
+	return i.i == nil
+}
+
+func (i Uint) NilToZero() Uint {
+	if i.IsNil() {
+		return ZeroUint()
+	}
+	return i
+}
+
 // IsZero returns true if Uint is zero
 func (i Uint) IsZero() bool {
 	return i.i.Sign() == 0
@@ -537,4 +550,27 @@ func (i *Uint) UnmarshalJSON(bz []byte) error {
 		i.i = new(big.Int)
 	}
 	return unmarshalJSON(i.i, bz)
+}
+
+//__________________________________________________________________________
+
+// UintOverflow returns true if a given unsigned integer overflows and false
+// otherwise.
+func UintOverflow(x Uint) bool {
+	return x.i.Sign() == -1 || x.i.Sign() == 1 && x.i.BitLen() > 256
+}
+
+// AddUint64Overflow performs the addition operation on two uint64 integers and
+// returns a boolean on whether or not the result overflows.
+func AddUint64Overflow(a, b uint64) (uint64, bool) {
+	if math.MaxUint64-a < b {
+		return 0, true
+	}
+
+	return a + b, false
+}
+
+// intended to be used with require/assert:  require.True(IntEq(...))
+func IntEq(t *testing.T, exp, got BigInt) (*testing.T, bool, string, string, string) {
+	return t, exp.Equal(got), "expected:\t%v\ngot:\t\t%v", exp.String(), got.String()
 }

--- a/types/result.go
+++ b/types/result.go
@@ -4,7 +4,10 @@ package types
 type Result struct {
 
 	// Code is the response code, is stored back on the chain.
-	Code ABCICodeType
+	Code CodeType
+
+	// Codespace is the string referring to the domain of an error
+	Codespace CodespaceType
 
 	// Data is any data returned from the app.
 	Data []byte
@@ -13,13 +16,13 @@ type Result struct {
 	Log string
 
 	// GasWanted is the maximum units of work we allow this tx to perform.
-	GasWanted int64
+	GasWanted uint64
 
 	// GasUsed is the amount of gas actually consumed. NOTE: unimplemented
-	GasUsed int64
+	GasUsed uint64
 
 	// Tx fee amount and denom.
-	FeeAmount int64
+	FeeAmount uint64
 	FeeDenom  string
 
 	// Tags are used for transaction indexing and pubsub.

--- a/types/utils.go
+++ b/types/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"regexp"
+	"time"
 
 	tmtypes "github.com/tendermint/tendermint/types"
 )
@@ -37,8 +38,8 @@ func MustSortJSON(toSortJSON []byte) []byte {
 	return js
 }
 
-// 函数：int64 转化为 []byte
-func Int2Byte(in int64) []byte {
+// 函数：uint64 转化为 []byte
+func Int2Byte(in uint64) []byte {
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, uint64(in))
 	return bz
@@ -60,6 +61,24 @@ func CheckQscName(qscName string) bool {
 	ret = !ret && !reg.Match([]byte(qscName))
 
 	return ret
+}
+
+// Slight modification of the RFC3339Nano but it right pads all zeros and drops the time zone info
+const SortableTimeFormat = "2006-01-02T15:04:05.000000000"
+
+// Formats a time.Time into a []byte that can be sorted
+func FormatTimeBytes(t time.Time) []byte {
+	return []byte(t.UTC().Round(0).Format(SortableTimeFormat))
+}
+
+// Parses a []byte encoded using FormatTimeKey back into a time.Time
+func ParseTimeBytes(bz []byte) (time.Time, error) {
+	str := string(bz)
+	t, err := time.Parse(SortableTimeFormat, str)
+	if err != nil {
+		return t, err
+	}
+	return t.UTC().Round(0), nil
 }
 
 func GetGenesisDoc(rootDir string) (*tmtypes.GenesisDoc, error) {


### PR DESCRIPTION
1.依赖tendermint版本更新为v0.27.0-dev1      
2.不能为负数的字段均使用uint64类型